### PR TITLE
Add an option to only show unlured guards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased
 
+- Minor: Add an option for only showing unlured guards in the overlay. (#24)
 - Minor: Khaled can now have a highlight if you don't have a task active. (#26)
 - Fix: Fixed an issue where Captain Khaled did not always get the arrow pointing to him. (#25)
 

--- a/src/main/java/io/cbitler/stealingartefacts/StealingArtefactsConfig.java
+++ b/src/main/java/io/cbitler/stealingartefacts/StealingArtefactsConfig.java
@@ -1,8 +1,10 @@
 package io.cbitler.stealingartefacts;
 
+import lombok.AllArgsConstructor;
 import net.runelite.client.config.Config;
 import net.runelite.client.config.ConfigGroup;
 import net.runelite.client.config.ConfigItem;
+import net.runelite.client.config.ConfigSection;
 
 @ConfigGroup("stealingartefacts")
 public interface StealingArtefactsConfig extends Config {
@@ -61,19 +63,56 @@ public interface StealingArtefactsConfig extends Config {
         return true;
     }
 
-    @ConfigItem(
-            keyName = SHOW_TO_NEXT_LEVEL,
-            name = "Show artefacts to next level",
-            description = "Whether or not to show artefacts to next level"
+    @ConfigSection(
+            name = "Overlay",
+            description = "asd",
+            position = 10,
+            closedByDefault = false
     )
-    default boolean showToNextLevel() { return true; }
+    String overlaySection = "Overlay";
 
     @ConfigItem(
             keyName = "showOverlay",
             name = "Show overlay",
-            description = "Uncheck this to hide the overlay"
+            description = "Uncheck this to hide the overlay",
+            section = overlaySection,
+            position = 1
     )
     default boolean showOverlay() {
         return true;
+    }
+
+    @ConfigItem(
+            keyName = SHOW_TO_NEXT_LEVEL,
+            name = "Show artefacts to next level",
+            description = "Whether or not to show artefacts to next level",
+            section = overlaySection,
+            position = 2
+    )
+    default boolean showToNextLevel() { return true; }
+
+    @AllArgsConstructor
+    enum OverlayShowGuardLure {
+        Always("Always"),
+        Never("Never"),
+        OnlyUnlured("Only unlured");
+
+        final String displayText;
+
+        @Override
+        public String toString() {
+            return this.displayText;
+        }
+    };
+
+    @ConfigItem(
+            keyName = "overlayShowGuardLures",
+            name = "Show guard lures",
+            description = "Uncheck this to hide the guard lure portion in the overlay",
+            section = overlaySection,
+            position = 3
+    )
+    default OverlayShowGuardLure overlayShowGuardLures() {
+        return OverlayShowGuardLure.Always;
     }
 }

--- a/src/main/java/io/cbitler/stealingartefacts/StealingArtefactsConfig.java
+++ b/src/main/java/io/cbitler/stealingartefacts/StealingArtefactsConfig.java
@@ -65,7 +65,7 @@ public interface StealingArtefactsConfig extends Config {
 
     @ConfigSection(
             name = "Overlay",
-            description = "asd",
+            description = "Controls the overlay display preferences",
             position = 10,
             closedByDefault = false
     )


### PR DESCRIPTION
This replaces the "Highlight lured guards" option for controlling the
overlay, you have three options:
 - "Always" - Always show guard lures in the overlay
 - "Never" - Never show guard lures in the overlay
 - "Only unlured" - Only show unlured guards in the overlay

![unsorted_20250316_14h28m27s](https://github.com/user-attachments/assets/c2c00edc-76e5-4690-8659-5a0608dbaa48)
